### PR TITLE
updated export NGSPICE_VERSION= 42  in iic-osic-setup.sh file

### DIFF
--- a/iic-osic-setup.sh
+++ b/iic-osic-setup.sh
@@ -31,7 +31,7 @@ export OPENLANE_DIR="$HOME/OpenLane"
 my_path=$(realpath "$0")
 my_dir=$(dirname "$my_path")
 export SCRIPT_DIR="$my_dir"
-export NGSPICE_VERSION=36
+export NGSPICE_VERSION= 42 
 # This selects which sky130 PDK flavor (A=sky130A, B=sky130B, all=both)  is installed
 export OPEN_PDK_ARGS="--with-sky130-variants=A"
 export MY_PDK=sky130A


### PR DESCRIPTION
In iic-osic-setup.sh file under setup environment setting NGSPICE version taken is 36 whereas latest version available for installation is 42.

Same has been updated:

```
# Define setup environment

# ------------------------

export MY_PDK_ROOT="$HOME/pdk"

export MY_STDCELL=sky130_fd_sc_hd

export SRC_DIR="$HOME/src"

export OPENLANE_DIR="$HOME/OpenLane"

my_path=$(realpath "$0")

my_dir=$(dirname "$my_path")

export SCRIPT_DIR="$my_dir"

export NGSPICE_VERSION= 42 

# This selects which sky130 PDK flavor (A=sky130A, B=sky130B, all=both)  is installed

export OPEN_PDK_ARGS="--with-sky130-variants=A"

export MY_PDK=sky130A


```