### PR TITLE
typo error in 'export NGSPICE_VERSION= 42' corrected by removing space

### DIFF
--- a/iic-osic-setup.sh
+++ b/iic-osic-setup.sh
@@ -31,7 +31,7 @@ export OPENLANE_DIR="$HOME/OpenLane"
 my_path=$(realpath "$0")
 my_dir=$(dirname "$my_path")
 export SCRIPT_DIR="$my_dir"
-export NGSPICE_VERSION= 42 
+export NGSPICE_VERSION=42 
 # This selects which sky130 PDK flavor (A=sky130A, B=sky130B, all=both)  is installed
 export OPEN_PDK_ARGS="--with-sky130-variants=A"
 export MY_PDK=sky130A


### PR DESCRIPTION
Space before 42 in 'export NGSPICE_VERSION= 42' was causing installation error. Same is rectified now.